### PR TITLE
[BF] bug-fixes in updates handling

### DIFF
--- a/src/main/kotlin/space/yaroslav/familybot/common/utils/MapUtils.kt
+++ b/src/main/kotlin/space/yaroslav/familybot/common/utils/MapUtils.kt
@@ -27,3 +27,9 @@ fun Update.toUser(): User {
     val formatedName = (user.firstName?.let { "$it " } ?: "") + (user.lastName ?: "")
     return User(user.id.toLong(), this.toChat(), formatedName, user.userName)
 }
+
+fun Update.checkDestinationBot(botName: String?): Boolean {
+    val destinationPattern = Regex(pattern = """\/[a-zA-Z]*[@]([a-zA-Z0-9]*).*""")
+    val destinationName: String = destinationPattern.matchEntire(this.message.text)?.groups?.get(1)?.value?.toUpperCase() ?: return true
+    return botName!!.toUpperCase() == destinationName
+}

--- a/src/main/kotlin/space/yaroslav/familybot/telegram/FamilyBot.kt
+++ b/src/main/kotlin/space/yaroslav/familybot/telegram/FamilyBot.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component
 import org.telegram.telegrambots.api.objects.Update
 import org.telegram.telegrambots.bots.TelegramLongPollingBot
 import org.telegram.telegrambots.exceptions.TelegramApiRequestException
+import space.yaroslav.familybot.common.utils.checkDestinationBot
 import space.yaroslav.familybot.common.utils.toUser
 import space.yaroslav.familybot.route.Router
 
@@ -20,8 +21,8 @@ class FamilyBot(val config: BotConfig, val router: Router) : TelegramLongPolling
     }
 
     override fun onUpdateReceived(update: Update?) {
-        if (!update!!.hasEditedMessage()) {
-            val toUser = update!!.toUser()
+        if (!update!!.hasEditedMessage() && update.checkDestinationBot(config.botname)) {
+            val toUser = update.toUser()
             MDC.put("chat", "${toUser.chat.name}:${toUser.chat.id}")
             MDC.put("user", "${toUser.name}:${toUser.id}")
             try {

--- a/src/main/kotlin/space/yaroslav/familybot/telegram/FamilyBot.kt
+++ b/src/main/kotlin/space/yaroslav/familybot/telegram/FamilyBot.kt
@@ -20,15 +20,17 @@ class FamilyBot(val config: BotConfig, val router: Router) : TelegramLongPolling
     }
 
     override fun onUpdateReceived(update: Update?) {
-        val toUser = update!!.toUser()
-        MDC.put("chat", "${toUser.chat.name}:${toUser.chat.id}")
-        MDC.put("user", "${toUser.name}:${toUser.id}")
-        try {
-            router.processUpdate(update).invoke(this).also { launch { MDC.clear() } }
-        } catch (e: TelegramApiRequestException) {
-            log.error("Telegram error: {}, {}, {}", e.apiResponse, e.errorCode, e.parameters, e)
-        } catch (e: Exception) {
-            log.error("Unexpected error", e)
+        if (!update!!.hasEditedMessage()) {
+            val toUser = update!!.toUser()
+            MDC.put("chat", "${toUser.chat.name}:${toUser.chat.id}")
+            MDC.put("user", "${toUser.name}:${toUser.id}")
+            try {
+                router.processUpdate(update).invoke(this).also { launch { MDC.clear() } }
+            } catch (e: TelegramApiRequestException) {
+                log.error("Telegram error: {}, {}, {}", e.apiResponse, e.errorCode, e.parameters, e)
+            } catch (e: Exception) {
+                log.error("Unexpected error", e)
+            }
         }
     }
 


### PR DESCRIPTION
## [BF] prevent 'edit' updates handling  ([7f3c769](https://github.com/AzZureman/familybot/commit/7f3c76927d66b9449430341bb4eb3a36744915a1))
If update has 'edited' message then it doesn't have user and message instances. So in this cause, when update has 'edited' message, it will have null values in user and message fields, that will lead to NullPointerException, if it not prevented.

## [BF] prevent hadling command destined for another bot  ([9d8b798](https://github.com/AzZureman/familybot/commit/9d8b7980a474bce571b5e7012fce414b81f19675))
In cause of bot's privacy is disabled, bot receive all updates, even commands that destined for another bot.