### PR TITLE
 Fixed: trigger the "Pshenitsin" keyword if the message starts with a space

### DIFF
--- a/src/main/kotlin/space/yaroslav/familybot/executors/eventbased/keyword/processor/PshenitsinKeyWordProcessor.kt
+++ b/src/main/kotlin/space/yaroslav/familybot/executors/eventbased/keyword/processor/PshenitsinKeyWordProcessor.kt
@@ -54,12 +54,10 @@ class PshenitsinKeyWordProcessor(
 
     private fun containsSymbolsY(text: String): Boolean {
         val splitText = text.split(Regex("\\s+"))
-
-        if (splitText.first().toCharArray().isEmpty())
-        {
-            return false
+        return if (splitText.first().toCharArray().isEmpty()) {
+            false
+        } else {
+            splitText.any { word -> word.toCharArray().all { c -> c.lowercaseChar() == 'ы' } }
         }
-        
-        return splitText.any { word -> word.toCharArray().all { c -> c.lowercaseChar() == 'ы' } }
     }
 }

--- a/src/main/kotlin/space/yaroslav/familybot/executors/eventbased/keyword/processor/PshenitsinKeyWordProcessor.kt
+++ b/src/main/kotlin/space/yaroslav/familybot/executors/eventbased/keyword/processor/PshenitsinKeyWordProcessor.kt
@@ -53,8 +53,13 @@ class PshenitsinKeyWordProcessor(
     }
 
     private fun containsSymbolsY(text: String): Boolean {
-        return text
-            .split(Regex("\\s+"))
-            .any { word -> word.toCharArray().all { c -> c.lowercaseChar() == 'ы' } }
+        val splitText = text.split(Regex("\\s+"))
+
+        if (splitText.first().toCharArray().isEmpty())
+        {
+            return false
+        }
+        
+        return splitText.any { word -> word.toCharArray().all { c -> c.lowercaseChar() == 'ы' } }
     }
 }


### PR DESCRIPTION
As in the title.

If the message starts with a space (can be sent with monospaced formatting, such as "`hello`"), the keyword "Pshenitsyn" is triggered.